### PR TITLE
Do not resolve Python Path symlinks for datafile hash

### DIFF
--- a/reentry/config.py
+++ b/reentry/config.py
@@ -71,7 +71,7 @@ def get_config(config_file_name=str(find_config())):
 def hashed_data_file_name():
     """Find the path to the reentry executable and mangle it into a file name."""
 
-    fname = 'u{bin_dir}_{impl}-{ver}'.format(bin_dir=Path(sys.executable).resolve().parent,
+    fname = 'u{bin_dir}_{impl}-{ver}'.format(bin_dir=Path(sys.executable).parent,
                                              impl=platform.python_implementation(),
                                              ver=platform.python_version())
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ deps = .[dev]
 install_command = pip install --pre --find-links={toxinidir}/dist --no-cache-dir --log=tox-pip.log {opts} {packages}
 
 commands = pytest --cov-report=term-missing --cov=reentry
-    reentry-test-hooks
     reentry scan
+    reentry-test-hooks
     reentry-test-hooks --with-noreg
 
 [testenv:py39-release]


### PR DESCRIPTION
Fixes #67 

In some cases, the Python binaries of multiple virtual environments can
be symlinks that point to the same file. In this case, the hash of the
reentry data file is the same for these environments, since
`Path.resolve()` also resolves symlinks.

As `sys.executable` already returns the absolute path to the environment
Python binary, we can just remove `.resolve()` to avoid resolving the
symlinks.